### PR TITLE
Support relative path for CMAKE_INSTALL_*DIR

### DIFF
--- a/msgpack-c.pc.in
+++ b/msgpack-c.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
-libdir=@libdir@
-includedir=@includedir@
+libdir=${prefix}/@libdir@
+includedir=${prefix}/@includedir@
 
 Name: MessagePack
 Description: Binary-based efficient object serialization library


### PR DESCRIPTION
## Problem

When `CMAKE_INSTALL_LIBDIR` and `CMAKE_INSTALL_INCLUDEDIR` are set to relative paths, the `msgpack-c.pc` file generated by CMake improperly configures `libdir` and `includedir`. This leads to incorrect paths that prevent the compiler from locating necessary header and library files.

## How to reproduce

Build and install `msgpack-c`.

```console
% git switch -c c_master
% cmake -S . -B ../msgpack-c.build -DCMAKE_INSTALL_PREFIX=/tmp/local -DCMAKE_INSTALL_LIBDIR=lib-relative -DCMAKE_INSTALL_INCLUDEDIR=include-relative
% cmake --build ../msgpack-c.build
% sudo cmake --install ../msgpack-c.build/
```

Compile `example/simple_c.c` using installed msgpack-c.
The following error happens because the linker cannot find paths provided by pkg-config.

```console
% export PKG_CONFIG_PATH=/usr/local/lib-relative/pkgconfig:$PKG_CONFIG_PATH
% gcc -o simple_c example/simple_c.c $(pkg-config --cflags --libs msgpack-c)
/usr/bin/ld: cannot find -lmsgpack-c: No such file or directory
collect2: error: ld returned 1 exit status
```

## Expected

Successly compile `example/simple_c.c` using install msgpack-c.
We can execute `simple_c.c` like the following.

```console
% gcc -o simple_c example/simple_c.c $(pkg-config --cflags --libs msgpack-c)
% ./simple_c
93 01 c3 a7 65 78 61 6d 70 6c 65
[1, true, "example"]
```

## Explain the problem in detail

The generated `msgpack-c.pc` file does not handle relative paths correctly. Here is an example of the incorrect configuration.
In the following `msgpack-c.pc` file, `libdir` and `includedir` are relative to the current directory, leading to incorrect paths.

```console
cat ../msgpack-c.build/msgpack-c.pc
prefix=/tmp/local
exec_prefix=/tmp/local
libdir=lib-relative
includedir=include-relative

Name: MessagePack
Description: Binary-based efficient object serialization library
Version: 6.0.1
Libs: -L${libdir} -lmsgpack-c
Cflags: -I${includedir}
```

## Soultion

Modify the `msgpack-c.pc.in` file to ensure that `libdir` and `includedir` use absolute paths by prefixing them with ${prefix}/. This change addresses the issue by providing correct paths to the compiler and linker.